### PR TITLE
Pin CI ruff and ty versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         run: uv sync
 
       - name: Type check
-        run: uvx ty check
+        run: uvx ty@0.0.63 check
 
       - name: Ruff check
-        run: uvx ruff check
+        run: uvx ruff@0.14.0 check
 
       - name: Test JSON-RPC
         run: uv run coverage run --data-file=.coverage.jsonrpc tests/jsonrpc_test.py


### PR DESCRIPTION
## Summary

- pin ty to 0.0.63
- pin Ruff to 0.14.0
- keep CI tooling changes independent from Literal/schema support
