### PR TITLE
Simplify Literal enums and JSON-RPC dispatch

### DIFF
--- a/benchmarks/dispatch.py
+++ b/benchmarks/dispatch.py
@@ -1,0 +1,63 @@
+"""Microbenchmark the in-process JSON-RPC and MCP dispatch paths."""
+
+import json
+import statistics
+import timeit
+
+from zeromcp import McpServer
+from zeromcp.jsonrpc import JsonRpcRegistry
+
+
+def measure(statement: str, *, number: int, scope: dict) -> float:
+    runs = timeit.repeat(statement, number=number, repeat=9, globals=scope)
+    return statistics.median(runs) / number * 1e9
+
+
+def main() -> None:
+    registry = JsonRpcRegistry()
+
+    @registry.method
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    rpc_request = {
+        "jsonrpc": "2.0",
+        "method": "add",
+        "params": {"a": 1, "b": 2},
+        "id": 1,
+    }
+
+    server = McpServer("benchmark")
+
+    @server.tool
+    def tool_add(a: int, b: int) -> int:
+        return a + b
+
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"name": "tool_add", "arguments": {"a": 1, "b": 2}},
+        "id": 1,
+    }
+
+    rpc_json = json.dumps(rpc_request)
+    mcp_json = json.dumps(mcp_request)
+
+    # Warm lazy caches before timing steady-state dispatch.
+    registry.dispatch(rpc_request)
+    server._dispatch_mcp(mcp_request)
+
+    scope = locals()
+    results = {
+        "direct function": measure("add(1, 2)", number=1_000_000, scope=scope),
+        "JSON-RPC dict": measure("registry.dispatch(rpc_request)", number=100_000, scope=scope),
+        "JSON-RPC JSON": measure("registry.dispatch(rpc_json)", number=100_000, scope=scope),
+        "MCP dict": measure("server._dispatch_mcp(mcp_request)", number=20_000, scope=scope),
+        "MCP JSON": measure("server._dispatch_mcp(mcp_json)", number=20_000, scope=scope),
+    }
+    for label, nanoseconds in results.items():
+        print(f"{label:20s} {nanoseconds:9.1f} ns/call  {1e9 / nanoseconds:10,.0f} calls/s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp_example.py
+++ b/examples/mcp_example.py
@@ -8,7 +8,7 @@ import base64
 import hashlib
 import argparse
 from urllib.parse import urlparse
-from typing import Annotated, Optional, TypedDict, NotRequired
+from typing import Annotated, Any, Optional, TypedDict, NotRequired
 from zeromcp import McpToolError, McpServer, McpAuthInfo
 
 mcp = McpServer("example")
@@ -108,7 +108,7 @@ def struct_get(
 
 
 @mcp.tool
-def random_dict(param: dict[str, int] | None) -> dict:
+def random_dict(param: dict[str, Any] | None) -> dict:
     """Return a random dictionary for testing serialization"""
     return {
         **(param or {}),

--- a/src/zeromcp/jsonrpc.py
+++ b/src/zeromcp/jsonrpc.py
@@ -3,8 +3,42 @@ import contextvars
 import inspect
 import json
 import traceback
-from typing import Any, Callable, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, is_typeddict
+from typing import Any, Callable, Literal, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, is_typeddict
 from types import UnionType
+from enum import Enum
+
+
+def _literal_json_value(value: Any) -> str | int | float | bool | None:
+    """Return the JSON wire value represented by a Literal member."""
+    if isinstance(value, Enum):
+        value = value.value
+    if value is None or type(value) in (str, int, float, bool):
+        return value
+    raise TypeError(f"Literal member {value!r} is not representable in JSON")
+
+
+def _match_literal(value: Any, members: tuple[Any, ...]) -> tuple[bool, Any]:
+    for member in members:
+        wire_value = _literal_json_value(member)
+        if value == wire_value and type(value) is type(wire_value):
+            return True, member
+    return False, value
+
+
+def _match_json_null(py_type: Any) -> tuple[bool, Any]:
+    if py_type is type(None):
+        return True, None
+    origin = get_origin(py_type)
+    args = get_args(py_type)
+    if origin is Literal:
+        return _match_literal(None, args)
+    if origin in (Union, UnionType):
+        for arg in args:
+            matched, literal_value = _match_json_null(arg)
+            if matched:
+                return True, literal_value
+    return False, None
+
 
 
 def _is_async_callable(func: Callable | None) -> bool:
@@ -257,21 +291,41 @@ class JsonRpcRegistry:
 
                 # Handle None/null
                 if value is None:
-                    if expected_type is not type(None):
-                        # Check if None is allowed in a Union
-                        if not (origin in (Union, UnionType) and type(None) in args):
-                            raise JsonRpcException(-32602, f"Invalid params: {param_name} cannot be null")
-                    validated_params[param_name] = None
+                    matched, literal_value = _match_json_null(expected_type)
+                    if not matched:
+                        raise JsonRpcException(-32602, f"Invalid params: {param_name} cannot be null")
+                    validated_params[param_name] = literal_value
+                    continue
+
+                # Handle Literal values before generic origins. Enum members are
+                # represented by their JSON-compatible values on the wire.
+                if origin is Literal:
+                    matched, literal_value = _match_literal(value, args)
+                    if not matched:
+                        raise JsonRpcException(
+                            -32602,
+                            f"Invalid params: {param_name} expected one of {list(args)!r}, got {value!r}",
+                        )
+                    validated_params[param_name] = literal_value
                     continue
 
                 # Handle Union types (int | str, Optional[int], etc.)
                 if origin in (Union, UnionType):
                     type_matched = False
+                    validated_value = value
                     for arg_type in args:
                         if arg_type is type(None):
                             continue
 
                         arg_origin = get_origin(arg_type)
+                        if arg_origin is Literal:
+                            matched, literal_value = _match_literal(value, get_args(arg_type))
+                            if matched:
+                                type_matched = True
+                                validated_value = literal_value
+                                break
+                            continue
+
                         check_type = arg_origin if arg_origin is not None else arg_type
 
                         # TypedDict cannot be used with isinstance - check for dict instead
@@ -284,7 +338,7 @@ class JsonRpcRegistry:
 
                     if not type_matched:
                         raise JsonRpcException(-32602, f"Invalid params: {param_name} union does not contain {type(value).__name__}")
-                    validated_params[param_name] = value
+                    validated_params[param_name] = validated_value
                     continue
 
                 # Handle generic types (list[X], dict[K,V])

--- a/src/zeromcp/jsonrpc.py
+++ b/src/zeromcp/jsonrpc.py
@@ -3,28 +3,60 @@ import contextvars
 import inspect
 import json
 import traceback
+from collections.abc import Mapping
 from typing import Annotated, Any, Callable, Literal, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, Required, is_typeddict
 from types import UnionType
 from enum import Enum
 
 
-def _literal_json_value(value: Any) -> str | int | float | bool | None:
-    """Return the JSON wire value represented by a Literal member."""
+def _literal_json_value(value: Any) -> Any:
+    """Return the recursively normalized JSON wire value of a Literal member."""
     if isinstance(value, Enum):
-        value = value.value
+        return _literal_json_value(value.value)
     if value is None or type(value) in (str, int, float, bool):
         return value
+    if isinstance(value, (list, tuple)):
+        return [_literal_json_value(item) for item in value]
+    if isinstance(value, Mapping):
+        result = {}
+        for key, item in value.items():
+            wire_key = _literal_json_value(key) if isinstance(key, Enum) else key
+            if type(wire_key) is not str:
+                raise TypeError(f"Literal mapping key {key!r} is not representable in JSON")
+            result[wire_key] = _literal_json_value(item)
+        return result
     raise TypeError(f"Literal member {value!r} is not representable in JSON")
+
+
+def _json_values_equal(value: Any, wire_value: Any, *, numeric_equivalence: bool) -> bool:
+    value_is_number = type(value) in (int, float)
+    wire_value_is_number = type(wire_value) in (int, float)
+    if value_is_number or wire_value_is_number:
+        return (
+            value_is_number
+            and wire_value_is_number
+            and (numeric_equivalence or type(value) is type(wire_value))
+            and value == wire_value
+        )
+    if type(value) is not type(wire_value):
+        return False
+    if isinstance(value, list):
+        return len(value) == len(wire_value) and all(
+            _json_values_equal(item, wire_item, numeric_equivalence=numeric_equivalence)
+            for item, wire_item in zip(value, wire_value)
+        )
+    if isinstance(value, dict):
+        return value.keys() == wire_value.keys() and all(
+            _json_values_equal(value[key], wire_value[key], numeric_equivalence=numeric_equivalence)
+            for key in value
+        )
+    return value == wire_value
 
 
 def _match_literal(value: Any, members: tuple[Any, ...]) -> tuple[bool, Any]:
     for member in members:
         wire_value = _literal_json_value(member)
-        value_is_number = type(value) in (int, float)
-        wire_value_is_number = type(wire_value) in (int, float)
-        if value == wire_value and (
-            type(value) is type(wire_value) or (value_is_number and wire_value_is_number)
-        ):
+        if _json_values_equal(value, wire_value, numeric_equivalence=True):
             return True, member
     return False, value
 
@@ -227,11 +259,14 @@ class JsonRpcRegistry:
         if origin in (Annotated, Required, NotRequired):
             return self._is_exact_union_match(value, args[0])
         if origin is Literal:
-            for member in args:
-                wire_value = _literal_json_value(member)
-                if value == wire_value and type(value) is type(wire_value):
-                    return True
-            return False
+            return any(
+                _json_values_equal(
+                    value,
+                    _literal_json_value(member),
+                    numeric_equivalence=False,
+                )
+                for member in args
+            )
         if origin in (Union, UnionType):
             return any(self._is_exact_union_match(value, arg_type) for arg_type in args)
         if is_typeddict(expected_type):

--- a/src/zeromcp/jsonrpc.py
+++ b/src/zeromcp/jsonrpc.py
@@ -23,6 +23,10 @@ def _literal_json_value(value: Any) -> Any:
             wire_key = _literal_json_value(key) if isinstance(key, Enum) else key
             if type(wire_key) is not str:
                 raise TypeError(f"Literal mapping key {key!r} is not representable in JSON")
+            if wire_key in result:
+                raise TypeError(
+                    f"Literal mapping key {key!r} normalizes to duplicate JSON key {wire_key!r}"
+                )
             result[wire_key] = _literal_json_value(item)
         return result
     raise TypeError(f"Literal member {value!r} is not representable in JSON")

--- a/src/zeromcp/jsonrpc.py
+++ b/src/zeromcp/jsonrpc.py
@@ -3,7 +3,7 @@ import contextvars
 import inspect
 import json
 import traceback
-from typing import Any, Callable, Literal, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, is_typeddict
+from typing import Annotated, Any, Callable, Literal, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, Required, is_typeddict
 from types import UnionType
 from enum import Enum
 
@@ -20,7 +20,11 @@ def _literal_json_value(value: Any) -> str | int | float | bool | None:
 def _match_literal(value: Any, members: tuple[Any, ...]) -> tuple[bool, Any]:
     for member in members:
         wire_value = _literal_json_value(member)
-        if value == wire_value and type(value) is type(wire_value):
+        value_is_number = type(value) in (int, float)
+        wire_value_is_number = type(wire_value) in (int, float)
+        if value == wire_value and (
+            type(value) is type(wire_value) or (value_is_number and wire_value_is_number)
+        ):
             return True, member
     return False, value
 
@@ -214,6 +218,127 @@ class JsonRpcRegistry:
             "message": "\n".join(traceback.format_exception(e)).strip() + "\n\nPlease report a bug!",
         }
 
+    def _is_exact_union_match(self, value: Any, expected_type: Any) -> bool:
+        if expected_type is Any:
+            return False
+
+        origin = get_origin(expected_type)
+        args = get_args(expected_type)
+        if origin in (Annotated, Required, NotRequired):
+            return self._is_exact_union_match(value, args[0])
+        if origin is Literal:
+            for member in args:
+                wire_value = _literal_json_value(member)
+                if value == wire_value and type(value) is type(wire_value):
+                    return True
+            return False
+        if origin in (Union, UnionType):
+            return any(self._is_exact_union_match(value, arg_type) for arg_type in args)
+        if is_typeddict(expected_type):
+            return isinstance(value, dict)
+        if origin is not None:
+            try:
+                return isinstance(value, origin)
+            except TypeError:
+                return False
+        return isinstance(expected_type, type) and type(value) is expected_type
+
+    def _validate_value(self, param_name: str, value: Any, expected_type: Any) -> Any:
+        if expected_type is Any:
+            return value
+
+        origin = get_origin(expected_type)
+        args = get_args(expected_type)
+
+        if origin in (Annotated, Required, NotRequired):
+            return self._validate_value(param_name, value, args[0])
+
+        if value is None:
+            matched, literal_value = _match_json_null(expected_type)
+            if not matched:
+                raise JsonRpcException(-32602, f"Invalid params: {param_name} cannot be null")
+            return literal_value
+
+        if origin is Literal:
+            matched, literal_value = _match_literal(value, args)
+            if not matched:
+                raise JsonRpcException(
+                    -32602,
+                    f"Invalid params: {param_name} expected one of {list(args)!r}, got {value!r}",
+                )
+            return literal_value
+
+        if origin in (Union, UnionType):
+            exact_args = [arg_type for arg_type in args if self._is_exact_union_match(value, arg_type)]
+            fallback_args = [arg_type for arg_type in args if not self._is_exact_union_match(value, arg_type)]
+            for arg_type in (*exact_args, *fallback_args):
+                try:
+                    return self._validate_value(param_name, value, arg_type)
+                except JsonRpcException:
+                    pass
+            raise JsonRpcException(
+                -32602,
+                f"Invalid params: {param_name} union does not contain {type(value).__name__}",
+            )
+
+        if origin is list:
+            if not isinstance(value, list):
+                raise JsonRpcException(
+                    -32602,
+                    f"Invalid params: {param_name} expected list, got {type(value).__name__}",
+                )
+            item_type = args[0] if args else Any
+            return [
+                self._validate_value(f"{param_name}[{index}]", item, item_type)
+                for index, item in enumerate(value)
+            ]
+
+        if origin is dict:
+            if not isinstance(value, dict):
+                raise JsonRpcException(
+                    -32602,
+                    f"Invalid params: {param_name} expected dict, got {type(value).__name__}",
+                )
+            key_type, value_type = args if len(args) == 2 else (Any, Any)
+            return {
+                self._validate_value(f"{param_name} key", key, key_type): self._validate_value(
+                    f"{param_name}[{key!r}]", item, value_type
+                )
+                for key, item in value.items()
+            }
+
+        if is_typeddict(expected_type):
+            if not isinstance(value, dict):
+                raise JsonRpcException(
+                    -32602,
+                    f"Invalid params: {param_name} expected dict, got {type(value).__name__}",
+                )
+            field_types = get_type_hints(expected_type, include_extras=True)
+            return {
+                key: self._validate_value(f"{param_name}.{key}", item, field_types[key])
+                if key in field_types else item
+                for key, item in value.items()
+            }
+
+        if origin is not None:
+            if not isinstance(value, origin):
+                raise JsonRpcException(
+                    -32602,
+                    f"Invalid params: {param_name} expected {origin.__name__}, got {type(value).__name__}",
+                )
+            return value
+
+        if isinstance(expected_type, type):
+            if expected_type is float and isinstance(value, int):
+                return float(value)
+            if not isinstance(value, expected_type):
+                raise JsonRpcException(
+                    -32602,
+                    f"Invalid params: {param_name} expected {expected_type.__name__}, got {type(value).__name__}",
+                )
+
+        return value
+
     def _call(self, method: str, params: Any) -> Any:
         if method not in self.methods:
             raise JsonRpcException(-32601, f"Method '{method}' not found")
@@ -282,103 +407,7 @@ class JsonRpcRegistry:
                     validated_params[param_name] = value
                     continue
 
-                # Has type hint, validate
-                expected_type = hints[param_name]
-
-                # Inline type validation
-                origin = get_origin(expected_type)
-                args = get_args(expected_type)
-
-                # Handle None/null
-                if value is None:
-                    matched, literal_value = _match_json_null(expected_type)
-                    if not matched:
-                        raise JsonRpcException(-32602, f"Invalid params: {param_name} cannot be null")
-                    validated_params[param_name] = literal_value
-                    continue
-
-                # Handle Literal values before generic origins. Enum members are
-                # represented by their JSON-compatible values on the wire.
-                if origin is Literal:
-                    matched, literal_value = _match_literal(value, args)
-                    if not matched:
-                        raise JsonRpcException(
-                            -32602,
-                            f"Invalid params: {param_name} expected one of {list(args)!r}, got {value!r}",
-                        )
-                    validated_params[param_name] = literal_value
-                    continue
-
-                # Handle Union types (int | str, Optional[int], etc.)
-                if origin in (Union, UnionType):
-                    type_matched = False
-                    validated_value = value
-                    for arg_type in args:
-                        if arg_type is type(None):
-                            continue
-
-                        arg_origin = get_origin(arg_type)
-                        if arg_origin is Literal:
-                            matched, literal_value = _match_literal(value, get_args(arg_type))
-                            if matched:
-                                type_matched = True
-                                validated_value = literal_value
-                                break
-                            continue
-
-                        check_type = arg_origin if arg_origin is not None else arg_type
-
-                        # TypedDict cannot be used with isinstance - check for dict instead
-                        if is_typeddict(arg_type):
-                            check_type = dict
-
-                        if isinstance(value, check_type):
-                            type_matched = True
-                            break
-
-                    if not type_matched:
-                        raise JsonRpcException(-32602, f"Invalid params: {param_name} union does not contain {type(value).__name__}")
-                    validated_params[param_name] = validated_value
-                    continue
-
-                # Handle generic types (list[X], dict[K,V])
-                if origin is not None:
-                    if not isinstance(value, origin):
-                        raise JsonRpcException(
-                            -32602,
-                            f"Invalid params: {param_name} expected {origin.__name__}, got {type(value).__name__}"
-                        )
-                    validated_params[param_name] = value
-                    continue
-
-                # Handle TypedDict (must check before basic types)
-                if is_typeddict(expected_type):
-                    if not isinstance(value, dict):
-                        raise JsonRpcException(
-                            -32602,
-                            f"Invalid params: {param_name} expected dict, got {type(value).__name__}"
-                        )
-                    validated_params[param_name] = value
-                    continue
-
-                # Handle Any
-                if expected_type is Any:
-                    validated_params[param_name] = value
-                    continue
-
-                # Handle basic types
-                if isinstance(expected_type, type):
-                    # Allow int -> float conversion
-                    if expected_type is float and isinstance(value, int):
-                        validated_params[param_name] = float(value)
-                        continue
-                    if not isinstance(value, expected_type):
-                        raise JsonRpcException(
-                            -32602,
-                            f"Invalid params: {param_name} expected {expected_type.__name__}, got {type(value).__name__}"
-                        )
-                    validated_params[param_name] = value
-                    continue
+                validated_params[param_name] = self._validate_value(param_name, value, hints[param_name])
 
             return func(**validated_params)
 

--- a/src/zeromcp/jsonrpc.py
+++ b/src/zeromcp/jsonrpc.py
@@ -3,81 +3,7 @@ import contextvars
 import inspect
 import json
 import traceback
-from collections.abc import Mapping
-from typing import Annotated, Any, Callable, Literal, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, Required, is_typeddict
-from types import UnionType
-from enum import Enum
-
-
-def _literal_json_value(value: Any) -> Any:
-    """Return the recursively normalized JSON wire value of a Literal member."""
-    if isinstance(value, Enum):
-        return _literal_json_value(value.value)
-    if value is None or type(value) in (str, int, float, bool):
-        return value
-    if isinstance(value, (list, tuple)):
-        return [_literal_json_value(item) for item in value]
-    if isinstance(value, Mapping):
-        result = {}
-        for key, item in value.items():
-            wire_key = _literal_json_value(key) if isinstance(key, Enum) else key
-            if type(wire_key) is not str:
-                raise TypeError(f"Literal mapping key {key!r} is not representable in JSON")
-            if wire_key in result:
-                raise TypeError(
-                    f"Literal mapping key {key!r} normalizes to duplicate JSON key {wire_key!r}"
-                )
-            result[wire_key] = _literal_json_value(item)
-        return result
-    raise TypeError(f"Literal member {value!r} is not representable in JSON")
-
-
-def _json_values_equal(value: Any, wire_value: Any, *, numeric_equivalence: bool) -> bool:
-    value_is_number = type(value) in (int, float)
-    wire_value_is_number = type(wire_value) in (int, float)
-    if value_is_number or wire_value_is_number:
-        return (
-            value_is_number
-            and wire_value_is_number
-            and (numeric_equivalence or type(value) is type(wire_value))
-            and value == wire_value
-        )
-    if type(value) is not type(wire_value):
-        return False
-    if isinstance(value, list):
-        return len(value) == len(wire_value) and all(
-            _json_values_equal(item, wire_item, numeric_equivalence=numeric_equivalence)
-            for item, wire_item in zip(value, wire_value)
-        )
-    if isinstance(value, dict):
-        return value.keys() == wire_value.keys() and all(
-            _json_values_equal(value[key], wire_value[key], numeric_equivalence=numeric_equivalence)
-            for key in value
-        )
-    return value == wire_value
-
-
-def _match_literal(value: Any, members: tuple[Any, ...]) -> tuple[bool, Any]:
-    for member in members:
-        wire_value = _literal_json_value(member)
-        if _json_values_equal(value, wire_value, numeric_equivalence=True):
-            return True, member
-    return False, value
-
-
-def _match_json_null(py_type: Any) -> tuple[bool, Any]:
-    if py_type is type(None):
-        return True, None
-    origin = get_origin(py_type)
-    args = get_args(py_type)
-    if origin is Literal:
-        return _match_literal(None, args)
-    if origin in (Union, UnionType):
-        for arg in args:
-            matched, literal_value = _match_json_null(arg)
-            if matched:
-                return True, literal_value
-    return False, None
+from typing import Any, Callable, TypedDict, TypeAlias, NotRequired
 
 
 
@@ -119,7 +45,6 @@ class JsonRpcNoResponse(Exception):
 class JsonRpcRegistry:
     def __init__(self):
         self.methods: dict[str, Callable] = {}
-        self._cache: dict[Callable, tuple[inspect.Signature, dict, list[str]]] = {}
         self._current_request: contextvars.ContextVar[JsonRpcId] = contextvars.ContextVar("zeromcp_current_request_id", default=None)
         self._async_dispatch: contextvars.ContextVar[bool] = contextvars.ContextVar("zeromcp_async_dispatch", default=False)
         self.redact_exceptions = False
@@ -254,204 +179,35 @@ class JsonRpcRegistry:
             "message": "\n".join(traceback.format_exception(e)).strip() + "\n\nPlease report a bug!",
         }
 
-    def _is_exact_union_match(self, value: Any, expected_type: Any) -> bool:
-        if expected_type is Any:
-            return False
-
-        origin = get_origin(expected_type)
-        args = get_args(expected_type)
-        if origin in (Annotated, Required, NotRequired):
-            return self._is_exact_union_match(value, args[0])
-        if origin is Literal:
-            return any(
-                _json_values_equal(
-                    value,
-                    _literal_json_value(member),
-                    numeric_equivalence=False,
-                )
-                for member in args
-            )
-        if origin in (Union, UnionType):
-            return any(self._is_exact_union_match(value, arg_type) for arg_type in args)
-        if is_typeddict(expected_type):
-            return isinstance(value, dict)
-        if origin is not None:
-            try:
-                return isinstance(value, origin)
-            except TypeError:
-                return False
-        return isinstance(expected_type, type) and type(value) is expected_type
-
-    def _validate_value(self, param_name: str, value: Any, expected_type: Any) -> Any:
-        if expected_type is Any:
-            return value
-
-        origin = get_origin(expected_type)
-        args = get_args(expected_type)
-
-        if origin in (Annotated, Required, NotRequired):
-            return self._validate_value(param_name, value, args[0])
-
-        if value is None:
-            matched, literal_value = _match_json_null(expected_type)
-            if not matched:
-                raise JsonRpcException(-32602, f"Invalid params: {param_name} cannot be null")
-            return literal_value
-
-        if origin is Literal:
-            matched, literal_value = _match_literal(value, args)
-            if not matched:
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: {param_name} expected one of {list(args)!r}, got {value!r}",
-                )
-            return literal_value
-
-        if origin in (Union, UnionType):
-            exact_args = [arg_type for arg_type in args if self._is_exact_union_match(value, arg_type)]
-            fallback_args = [arg_type for arg_type in args if not self._is_exact_union_match(value, arg_type)]
-            for arg_type in (*exact_args, *fallback_args):
-                try:
-                    return self._validate_value(param_name, value, arg_type)
-                except JsonRpcException:
-                    pass
-            raise JsonRpcException(
-                -32602,
-                f"Invalid params: {param_name} union does not contain {type(value).__name__}",
-            )
-
-        if origin is list:
-            if not isinstance(value, list):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: {param_name} expected list, got {type(value).__name__}",
-                )
-            item_type = args[0] if args else Any
-            return [
-                self._validate_value(f"{param_name}[{index}]", item, item_type)
-                for index, item in enumerate(value)
-            ]
-
-        if origin is dict:
-            if not isinstance(value, dict):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: {param_name} expected dict, got {type(value).__name__}",
-                )
-            key_type, value_type = args if len(args) == 2 else (Any, Any)
-            return {
-                self._validate_value(f"{param_name} key", key, key_type): self._validate_value(
-                    f"{param_name}[{key!r}]", item, value_type
-                )
-                for key, item in value.items()
-            }
-
-        if is_typeddict(expected_type):
-            if not isinstance(value, dict):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: {param_name} expected dict, got {type(value).__name__}",
-                )
-            field_types = get_type_hints(expected_type, include_extras=True)
-            return {
-                key: self._validate_value(f"{param_name}.{key}", item, field_types[key])
-                if key in field_types else item
-                for key, item in value.items()
-            }
-
-        if origin is not None:
-            if not isinstance(value, origin):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: {param_name} expected {origin.__name__}, got {type(value).__name__}",
-                )
-            return value
-
-        if isinstance(expected_type, type):
-            if expected_type is float and isinstance(value, int):
-                return float(value)
-            if not isinstance(value, expected_type):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: {param_name} expected {expected_type.__name__}, got {type(value).__name__}",
-                )
-
-        return value
-
     def _call(self, method: str, params: Any) -> Any:
-        if method not in self.methods:
-            raise JsonRpcException(-32601, f"Method '{method}' not found")
+        try:
+            func = self.methods[method]
+        except KeyError:
+            raise JsonRpcException(-32601, f"Method '{method}' not found") from None
 
-        func = self.methods[method]
-
-        # Check for cached reflection data
-        if func not in self._cache:
-            sig = inspect.signature(func)
-            hints = get_type_hints(func)
-            hints.pop("return", None)
-
-            # Determine required vs optional parameters
-            required_params = []
-            for param_name, param in sig.parameters.items():
-                if param.default is inspect.Parameter.empty:
-                    required_params.append(param_name)
-
-            self._cache[func] = (sig, hints, required_params)
-
-        sig, hints, required_params = self._cache[func]
-
-        # Handle None params
         if params is None:
-            if len(required_params) == 0:
-                return func()
-            else:
-                raise JsonRpcException(-32602, "Missing required params")
-
-        # Convert list params to dict by parameter names
-        if isinstance(params, list):
-            if len(params) < len(required_params):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: expected at least {len(required_params)} arguments, got {len(params)}"
-                )
-            if len(params) > len(sig.parameters):
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: expected at most {len(sig.parameters)} arguments, got {len(params)}"
-                )
-            params = dict(zip(sig.parameters.keys(), params))
-
-        # Validate dict params
-        if isinstance(params, dict):
-            # Check all required params are present
-            missing = set(required_params) - set(params.keys())
-            if missing:
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: missing required parameters: {list(missing)}"
-                )
-
-            # Check no extra params
-            extra = set(params.keys()) - set(sig.parameters.keys())
-            if extra:
-                raise JsonRpcException(
-                    -32602,
-                    f"Invalid params: unexpected parameters: {list(extra)}"
-                )
-
-            validated_params = {}
-            for param_name, value in params.items():
-                # If no type hint, pass through without validation
-                if param_name not in hints:
-                    validated_params[param_name] = value
-                    continue
-
-                validated_params[param_name] = self._validate_value(param_name, value, hints[param_name])
-
-            return func(**validated_params)
-
+            args, kwargs = (), {}
+        elif isinstance(params, list):
+            args, kwargs = params, {}
+        elif isinstance(params, dict):
+            args, kwargs = (), params
         else:
             raise JsonRpcException(-32602, "Invalid params: must be array or object")
+
+        try:
+            return func(*args, **kwargs)
+        except TypeError:
+            # Only inspect the signature on the error path. This distinguishes bad
+            # arguments from a TypeError raised inside the function.
+            try:
+                signature = inspect.signature(func)
+            except (TypeError, ValueError):
+                raise
+            try:
+                signature.bind(*args, **kwargs)
+            except TypeError as exc:
+                raise JsonRpcException(-32602, f"Invalid params: {exc}") from None
+            raise
 
     def _error(self, request_id: JsonRpcId, code: int, message: str, data: Any = None) -> JsonRpcResponse:
         error: JsonRpcError = {

--- a/src/zeromcp/mcp.py
+++ b/src/zeromcp/mcp.py
@@ -14,12 +14,12 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
-from typing import Any, Callable, Union, Annotated, BinaryIO, Mapping, NotRequired, Required, get_origin, get_args, get_type_hints, is_typeddict
+from typing import Any, Callable, Union, Annotated, BinaryIO, Literal, Mapping, NotRequired, Required, get_origin, get_args, get_type_hints, is_typeddict
 from types import UnionType
 from urllib.parse import urlparse, parse_qs
 from io import BufferedIOBase
 
-from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoResponse, _is_async_callable
+from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoResponse, _is_async_callable, _literal_json_value
 
 # Deliberately not the newest supported version: older, half-compliant clients
 # are more likely to work when negotiation falls back to 2025-06-18.
@@ -1359,6 +1359,17 @@ class McpServer:
         # Required[T] / NotRequired[T]
         if origin in (Required, NotRequired):
             return self._type_to_json_schema(get_args(py_type)[0])
+
+        # Literal[value, ...]
+        if origin is Literal:
+            values = [_literal_json_value(value) for value in get_args(py_type)]
+            schema: dict[str, Any] = {"enum": values}
+            value_types = {type(value) for value in values}
+            if len(value_types) == 1:
+                value_schema = self._type_to_json_schema(next(iter(value_types)))
+                if value_schema.get("type") != "object":
+                    schema = {**value_schema, **schema}
+            return schema
 
         # Union[Ts..], Optional[T] and T1 | T2
         if origin in (Union, UnionType):

--- a/src/zeromcp/mcp.py
+++ b/src/zeromcp/mcp.py
@@ -30,11 +30,16 @@ def _json_wire_value(value: Any) -> Any:
     if isinstance(value, Mapping):
         result = {}
         for key, item in value.items():
+            original_key = key
             if isinstance(key, Enum):
                 wire_key = _literal_json_value(key)
                 if wire_key is not None and type(wire_key) not in (str, int, float, bool):
                     raise TypeError(f"Enum mapping key {key!r} has a non-scalar JSON value")
                 key = wire_key
+            if key in result:
+                raise TypeError(
+                    f"Mapping key {original_key!r} normalizes to duplicate JSON key {key!r}"
+                )
             result[key] = _json_wire_value(item)
         return result
     if isinstance(value, (list, tuple)):

--- a/src/zeromcp/mcp.py
+++ b/src/zeromcp/mcp.py
@@ -13,6 +13,7 @@ import contextvars
 from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
+from enum import Enum
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
 from typing import Any, Callable, Union, Annotated, BinaryIO, Literal, Mapping, NotRequired, Required, get_origin, get_args, get_type_hints, is_typeddict
 from types import UnionType
@@ -20,6 +21,18 @@ from urllib.parse import urlparse, parse_qs
 from io import BufferedIOBase
 
 from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoResponse, _is_async_callable, _literal_json_value
+
+
+def _json_wire_value(value: Any) -> Any:
+    """Recursively replace Enum members with their JSON wire values."""
+    if isinstance(value, Enum):
+        return _literal_json_value(value)
+    if isinstance(value, Mapping):
+        return {key: _json_wire_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_wire_value(item) for item in value]
+    return value
+
 
 # Deliberately not the newest supported version: older, half-compliant clients
 # are more likely to work when negotiation falls back to 2025-06-18.
@@ -1140,7 +1153,7 @@ class McpServer:
                 "isError": True,
             }
 
-        result = tool_response.get("result")
+        result = _json_wire_value(tool_response.get("result"))
         content = result if isinstance(result, str) else json.dumps(result, indent=2)
         mcp_result = {
             "content": [{"type": "text", "text": content}],

--- a/src/zeromcp/mcp.py
+++ b/src/zeromcp/mcp.py
@@ -24,11 +24,12 @@ from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoR
 
 
 def _literal_json_value(value: Any) -> str | int | float | bool | None:
-    """Return a JSON scalar, allowing only Enum members derived from str."""
+    """Return the JSON scalar represented by a Literal member."""
     if isinstance(value, Enum):
-        if not isinstance(value, str):
-            raise TypeError(f"Enum Literal member {value!r} must derive from str")
-        return value.value
+        enum_value = value.value
+        if type(enum_value) not in (str, int, float):
+            raise TypeError(f"Enum Literal member {value!r} must have a str, int, or float value")
+        return enum_value
     if value is None or type(value) in (str, int, float, bool):
         return value
     raise TypeError(f"Literal member {value!r} is not a JSON scalar")
@@ -1517,11 +1518,16 @@ class McpServer:
                 required.append(param_name)
             else:
                 try:
-                    json.dumps(param.default)
+                    default = (
+                        _literal_json_value(param.default)
+                        if isinstance(param.default, Enum)
+                        else param.default
+                    )
+                    json.dumps(default)
                 except TypeError:
                     pass
                 else:
-                    properties[param_name]["default"] = param.default
+                    properties[param_name]["default"] = default
 
         schema: dict[str, Any] = {
             "name": func_name,

--- a/src/zeromcp/mcp.py
+++ b/src/zeromcp/mcp.py
@@ -20,31 +20,18 @@ from types import UnionType
 from urllib.parse import urlparse, parse_qs
 from io import BufferedIOBase
 
-from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoResponse, _is_async_callable, _literal_json_value
+from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoResponse, _is_async_callable
 
 
-def _json_wire_value(value: Any) -> Any:
-    """Recursively replace Enum members, including mapping keys, with wire values."""
+def _literal_json_value(value: Any) -> str | int | float | bool | None:
+    """Return a JSON scalar, allowing only Enum members derived from str."""
     if isinstance(value, Enum):
-        return _literal_json_value(value)
-    if isinstance(value, Mapping):
-        result = {}
-        for key, item in value.items():
-            original_key = key
-            if isinstance(key, Enum):
-                wire_key = _literal_json_value(key)
-                if wire_key is not None and type(wire_key) not in (str, int, float, bool):
-                    raise TypeError(f"Enum mapping key {key!r} has a non-scalar JSON value")
-                key = wire_key
-            if key in result:
-                raise TypeError(
-                    f"Mapping key {original_key!r} normalizes to duplicate JSON key {key!r}"
-                )
-            result[key] = _json_wire_value(item)
-        return result
-    if isinstance(value, (list, tuple)):
-        return [_json_wire_value(item) for item in value]
-    return value
+        if not isinstance(value, str):
+            raise TypeError(f"Enum Literal member {value!r} must derive from str")
+        return value.value
+    if value is None or type(value) in (str, int, float, bool):
+        return value
+    raise TypeError(f"Literal member {value!r} is not a JSON scalar")
 
 
 # Deliberately not the newest supported version: older, half-compliant clients
@@ -649,6 +636,8 @@ class McpServer:
         self.tools = McpRpcRegistry()
         self.resources = McpRpcRegistry()
         self.prompts = McpRpcRegistry()
+        self._tool_is_async: dict[str, bool] = {}
+        self._tool_result_modes: dict[str, str] = {}
 
         self._http_server: HTTPServer | None = None
         self._server_thread: threading.Thread | None = None
@@ -746,6 +735,9 @@ class McpServer:
         def decorator(inner: Callable) -> Callable:
             if annotations:
                 setattr(inner, "__mcp_tool_annotations__", annotations)
+            name = getattr(inner, "__name__", inner.__class__.__name__)
+            self._tool_is_async[name] = _is_async_callable(inner)
+            self._tool_result_modes.pop(name, None)
             return self.tools.method(inner)
 
         return decorator if func is None else decorator(func)
@@ -1046,7 +1038,11 @@ class McpServer:
 
     def _mcp_tools_call(self, name: str, arguments: dict | None = None, _meta: dict | None = None):
         """MCP tools/call method"""
-        # Wrap tool call in JSON-RPC request so argument validation stays shared.
+        is_async = self._tool_is_async.get(name)
+        if is_async is None:
+            is_async = _is_async_callable(self.tools.methods.get(name))
+            self._tool_is_async[name] = is_async
+
         return self._dispatch_nested_mcp(
             self.tools,
             {
@@ -1057,7 +1053,7 @@ class McpServer:
             },
             lambda tool_response: self._format_tool_response(name, tool_response),
             meta=_meta,
-            cancellable=_is_async_callable(self.tools.methods.get(name)),
+            cancellable=is_async,
         )
 
     def _dispatch_nested_mcp(
@@ -1166,7 +1162,7 @@ class McpServer:
                 "isError": True,
             }
 
-        result = _json_wire_value(tool_response.get("result"))
+        result = tool_response.get("result")
         content = result if isinstance(result, str) else json.dumps(result, indent=2)
         mcp_result = {
             "content": [{"type": "text", "text": content}],
@@ -1189,15 +1185,23 @@ class McpServer:
                 cancellation.cancel(reason)
 
     def _structured_content_for_tool(self, name: str, result: Any) -> dict | None:
-        func = self.tools.methods.get(name)
-        if func is not None:
-            return_type = get_type_hints(func, include_extras=True).get("return")
+        mode = self._tool_result_modes.get(name)
+        if mode is None:
+            func = self.tools.methods.get(name)
+            return_type = get_type_hints(func, include_extras=True).get("return") if func else None
             if self._type_is_plain_str(return_type):
-                return None
-            if return_type and return_type is not type(None) and return_type is not Any:
-                if not self._schema_is_object_like(self._type_to_json_schema(return_type)):
-                    return {"result": result}
-        return result if isinstance(result, dict) else {"result": result}
+                mode = "text"
+            elif return_type and return_type is not type(None) and return_type is not Any:
+                mode = "object" if self._schema_is_object_like(self._type_to_json_schema(return_type)) else "wrapped"
+            else:
+                mode = "object"
+            self._tool_result_modes[name] = mode
+
+        if mode == "text":
+            return None
+        if mode == "object" and isinstance(result, dict):
+            return result
+        return {"result": result}
 
     def _enumerate_resources(self):
         for name, func in self.resources.methods.items():
@@ -1393,7 +1397,8 @@ class McpServer:
             value_types = {type(value) for value in values}
             if len(value_types) == 1:
                 value_schema = self._type_to_json_schema(next(iter(value_types)))
-                schema = {**value_schema, **schema}
+                if value_schema.get("type") != "object":
+                    schema = {**value_schema, **schema}
             return schema
 
         # Union[Ts..], Optional[T] and T1 | T2

--- a/src/zeromcp/mcp.py
+++ b/src/zeromcp/mcp.py
@@ -24,11 +24,19 @@ from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, JsonRpcNoR
 
 
 def _json_wire_value(value: Any) -> Any:
-    """Recursively replace Enum members with their JSON wire values."""
+    """Recursively replace Enum members, including mapping keys, with wire values."""
     if isinstance(value, Enum):
         return _literal_json_value(value)
     if isinstance(value, Mapping):
-        return {key: _json_wire_value(item) for key, item in value.items()}
+        result = {}
+        for key, item in value.items():
+            if isinstance(key, Enum):
+                wire_key = _literal_json_value(key)
+                if wire_key is not None and type(wire_key) not in (str, int, float, bool):
+                    raise TypeError(f"Enum mapping key {key!r} has a non-scalar JSON value")
+                key = wire_key
+            result[key] = _json_wire_value(item)
+        return result
     if isinstance(value, (list, tuple)):
         return [_json_wire_value(item) for item in value]
     return value
@@ -1380,8 +1388,7 @@ class McpServer:
             value_types = {type(value) for value in values}
             if len(value_types) == 1:
                 value_schema = self._type_to_json_schema(next(iter(value_types)))
-                if value_schema.get("type") != "object":
-                    schema = {**value_schema, **schema}
+                schema = {**value_schema, **schema}
             return schema
 
         # Union[Ts..], Optional[T] and T1 | T2

--- a/tests/jsonrpc_test.py
+++ b/tests/jsonrpc_test.py
@@ -6,8 +6,7 @@ import json
 import sys
 import traceback
 import re
-from enum import Enum
-from typing import Optional, Any, Literal, TypedDict
+from typing import Optional, Any, TypedDict
 
 from zeromcp.jsonrpc import JsonRpcRegistry
 
@@ -53,51 +52,6 @@ def exact_union_test(value: float | bool | int) -> str:
 @jsonrpc.method
 def list_test(items: list[str]) -> int:
     return len(items)
-
-@jsonrpc.method
-def literal_test(mode: Literal["fast", "safe"]) -> str:
-    return mode
-
-@jsonrpc.method
-def literal_union_test(mode: Literal["auto"] | int) -> str:
-    return str(mode)
-
-@jsonrpc.method
-def nullable_literal_test(mode: Literal["auto", None]) -> str:
-    return repr(mode)
-
-@jsonrpc.method
-def nullable_literal_union_test(mode: Literal[None] | str) -> str:
-    return repr(mode)
-
-class NullMode(Enum):
-    NULL = None
-
-@jsonrpc.method
-def nullable_enum_literal_union_test(mode: Literal[NullMode.NULL] | str) -> str:
-    return mode.name if isinstance(mode, NullMode) else mode
-
-class Ratio(Enum):
-    ONE = 1.0
-
-@jsonrpc.method
-def numeric_enum_literal_test(ratio: Literal[Ratio.ONE]) -> str:
-    return ratio.name
-
-class BackendMode(Enum):
-    GUI = "gui"
-
-class NestedLiteralOptions(TypedDict):
-    backend: Literal[BackendMode.GUI]
-    fallbacks: list[Literal[BackendMode.GUI]]
-    aliases: dict[str, Literal[BackendMode.GUI]]
-
-@jsonrpc.method
-def nested_literal_test(options: NestedLiteralOptions) -> str:
-    assert options["backend"] is BackendMode.GUI
-    assert options["fallbacks"] == [BackendMode.GUI]
-    assert options["aliases"] == {"default": BackendMode.GUI}
-    return "ok"
 
 @jsonrpc.method
 def exception():
@@ -404,56 +358,38 @@ def run_all_tests():
     )
 
     # ========================================
-    # PARAMETER VALIDATION TESTS
+    # ARGUMENT BINDING TESTS
     # ========================================
 
-    # Wrong number of positional params - too few
+    # Python handles argument binding; annotations are not revalidated here.
     check_rpc(
         '{"jsonrpc": "2.0", "method": "subtract", "params": [42], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: expected at least 2 arguments, got 1"}, "id": 1},
+        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "regex:^Invalid params: .*missing.*subtrahend"}, "id": 1},
         "Invalid params - too few positional arguments"
     )
 
-    # Wrong number of positional params - too many
     check_rpc(
         '{"jsonrpc": "2.0", "method": "subtract", "params": [42, 23, 10], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: expected at most 2 arguments, got 3"}, "id": 1},
+        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "regex:^Invalid params: .*positional arguments"}, "id": 1},
         "Invalid params - too many positional arguments"
     )
 
-    # Missing required named param
     check_rpc(
         '{"jsonrpc": "2.0", "method": "subtract", "params": {"minuend": 42}, "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: missing required parameters: ['subtrahend']"}, "id": 1},
+        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "regex:^Invalid params: .*missing.*subtrahend"}, "id": 1},
         "Invalid params - missing required parameter"
     )
 
-    # Extra named param
     check_rpc(
         '{"jsonrpc": "2.0", "method": "subtract", "params": {"minuend": 42, "subtrahend": 23, "extra": 1}, "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: unexpected parameters: ['extra']"}, "id": 1},
+        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "regex:^Invalid params: .*unexpected keyword.*extra"}, "id": 1},
         "Invalid params - unexpected parameter"
     )
 
-    # Wrong type - string instead of int
     check_rpc(
         '{"jsonrpc": "2.0", "method": "subtract", "params": [42, "not a number"], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: subtrahend expected int, got str"}, "id": 1},
-        "Invalid params - wrong type (str instead of int)"
-    )
-
-    # Wrong type - list instead of int
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "subtract", "params": {"minuend": 42, "subtrahend": [1, 2]}, "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: subtrahend expected int, got list"}, "id": 1},
-        "Invalid params - wrong type (list instead of int)"
-    )
-
-    # Null for non-optional param
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "subtract", "params": [42, null], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: subtrahend cannot be null"}, "id": 1},
-        "Invalid params - null for non-optional parameter"
+        {"jsonrpc": "2.0", "error": {"code": -32603, "message": "regex:unsupported operand"}, "id": 1},
+        "Annotations are not runtime validation"
     )
 
     # Params is invalid type (not array or object)
@@ -471,7 +407,7 @@ def run_all_tests():
 
     check_rpc(
         '{"jsonrpc": "2.0", "method": "subtract", "params": null, "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Missing required params"}, "id": 1},
+        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "regex:^Invalid params: .*missing"}, "id": 1},
         "Invalid params - null for required params"
     )
 
@@ -546,11 +482,11 @@ def run_all_tests():
         "Union type (int | str) - str value"
     )
 
-    # Union type - invalid type
+    # Type annotations are schema metadata, not runtime validation.
     check_rpc(
         '{"jsonrpc": "2.0", "method": "union_test", "params": [[1, 2, 3]], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: id union does not contain list"}, "id": 1},
-        "Union type (int | str) - invalid list"
+        {"jsonrpc": "2.0", "result": "ID: [1, 2, 3]", "id": 1},
+        "Union annotation is not revalidated"
     )
 
     # Union type - null
@@ -601,102 +537,11 @@ def run_all_tests():
         "Generic type list[str] - valid list"
     )
 
-    # list[T] - wrong outer type
+    # The function receives decoded JSON directly, regardless of annotations.
     check_rpc(
         '{"jsonrpc": "2.0", "method": "list_test", "params": ["not a list"], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: items expected list, got str"}, "id": 1},
-        "Generic type list[str] - wrong outer type"
-    )
-
-    # Literal - valid value
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "literal_test", "params": ["fast"], "id": 1}',
-        {"jsonrpc": "2.0", "result": "fast", "id": 1},
-        "Literal - valid value"
-    )
-
-    # Literal - invalid value
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "literal_test", "params": ["other"], "id": 1}',
-        {
-            "jsonrpc": "2.0",
-            "error": {
-                "code": -32602,
-                "message": "Invalid params: mode expected one of ['fast', 'safe'], got 'other'",
-            },
-            "id": 1,
-        },
-        "Literal - invalid value"
-    )
-
-    # Literal nested in a union
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "literal_union_test", "params": ["auto"], "id": 1}',
-        {"jsonrpc": "2.0", "result": "auto", "id": 1},
-        "Literal union - literal value"
-    )
-
-    # Literal containing None accepts JSON null
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "nullable_literal_test", "params": [null], "id": 1}',
-        {"jsonrpc": "2.0", "result": "None", "id": 1},
-        "Literal - null member"
-    )
-
-    # A nested Literal union arm accepts JSON null
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "nullable_literal_union_test", "params": [null], "id": 1}',
-        {"jsonrpc": "2.0", "result": "None", "id": 1},
-        "Literal union - null member"
-    )
-
-    # An Enum Literal whose JSON wire value is null also accepts JSON null
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "nullable_enum_literal_union_test", "params": [null], "id": 1}',
-        {"jsonrpc": "2.0", "result": "NULL", "id": 1},
-        "Enum Literal union - null wire value"
-    )
-
-    # JSON integers and floats use the same numeric equality semantics
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "numeric_enum_literal_test", "params": [1], "id": 1}',
-        {"jsonrpc": "2.0", "result": "ONE", "id": 1},
-        "Enum Literal - equivalent JSON number"
-    )
-
-    # JSON booleans remain distinct from numbers
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "numeric_enum_literal_test", "params": [true], "id": 1}',
-        {
-            "jsonrpc": "2.0",
-            "error": {
-                "code": -32602,
-                "message": "Invalid params: ratio expected one of [<Ratio.ONE: 1.0>], got True",
-            },
-            "id": 1,
-        },
-        "Enum Literal - boolean is not a number"
-    )
-
-    # Literal enum values are converted recursively inside containers
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "nested_literal_test", "params": [{"backend": "gui", "fallbacks": ["gui"], "aliases": {"default": "gui"}}], "id": 1}',
-        {"jsonrpc": "2.0", "result": "ok", "id": 1},
-        "Enum Literal - nested container conversion"
-    )
-
-    # Schema-invalid nested Literal values are rejected
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "nested_literal_test", "params": [{"backend": "other", "fallbacks": [], "aliases": {}}], "id": 1}',
-        {
-            "jsonrpc": "2.0",
-            "error": {
-                "code": -32602,
-                "message": "Invalid params: options.backend expected one of [<BackendMode.GUI: 'gui'>], got 'other'",
-            },
-            "id": 1,
-        },
-        "Enum Literal - reject invalid nested value"
+        {"jsonrpc": "2.0", "result": 10, "id": 1},
+        "Generic annotation is not revalidated"
     )
 
     # Point TypedDict - valid dict
@@ -706,18 +551,11 @@ def run_all_tests():
         "TypedDict Point - valid dict"
     )
 
-    # Point TypedDict - wrong outer type
-    check_rpc(
-        '{"jsonrpc": "2.0", "method": "point_pretty", "params": ["not a dict"], "id": 1}',
-        {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: p expected dict, got str"}, "id": 1},
-        "TypedDict Point - wrong outer type"
-    )
-
-    # Convert from int to float
+    # Numeric JSON values are passed through without coercion.
     check_rpc(
         '{"jsonrpc": "2.0", "method": "round_float", "params": [3], "id": 1}',
         {"jsonrpc": "2.0", "result": 3, "id": 1},
-        "Convert int to float for float parameter"
+        "Numeric value passed through"
     )
 
     # Any type - various inputs

--- a/tests/jsonrpc_test.py
+++ b/tests/jsonrpc_test.py
@@ -6,7 +6,8 @@ import json
 import sys
 import traceback
 import re
-from typing import Optional, Any, TypedDict
+from enum import Enum
+from typing import Optional, Any, Literal, TypedDict
 
 from zeromcp.jsonrpc import JsonRpcRegistry
 
@@ -48,6 +49,29 @@ def union_test(id: int | str | None | Point) -> str:
 @jsonrpc.method
 def list_test(items: list[str]) -> int:
     return len(items)
+
+@jsonrpc.method
+def literal_test(mode: Literal["fast", "safe"]) -> str:
+    return mode
+
+@jsonrpc.method
+def literal_union_test(mode: Literal["auto"] | int) -> str:
+    return str(mode)
+
+@jsonrpc.method
+def nullable_literal_test(mode: Literal["auto", None]) -> str:
+    return repr(mode)
+
+@jsonrpc.method
+def nullable_literal_union_test(mode: Literal[None] | str) -> str:
+    return repr(mode)
+
+class NullMode(Enum):
+    NULL = None
+
+@jsonrpc.method
+def nullable_enum_literal_union_test(mode: Literal[NullMode.NULL] | str) -> str:
+    return mode.name if isinstance(mode, NullMode) else mode
 
 @jsonrpc.method
 def exception():
@@ -544,6 +568,55 @@ def run_all_tests():
         '{"jsonrpc": "2.0", "method": "list_test", "params": ["not a list"], "id": 1}',
         {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Invalid params: items expected list, got str"}, "id": 1},
         "Generic type list[str] - wrong outer type"
+    )
+
+    # Literal - valid value
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "literal_test", "params": ["fast"], "id": 1}',
+        {"jsonrpc": "2.0", "result": "fast", "id": 1},
+        "Literal - valid value"
+    )
+
+    # Literal - invalid value
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "literal_test", "params": ["other"], "id": 1}',
+        {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32602,
+                "message": "Invalid params: mode expected one of ['fast', 'safe'], got 'other'",
+            },
+            "id": 1,
+        },
+        "Literal - invalid value"
+    )
+
+    # Literal nested in a union
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "literal_union_test", "params": ["auto"], "id": 1}',
+        {"jsonrpc": "2.0", "result": "auto", "id": 1},
+        "Literal union - literal value"
+    )
+
+    # Literal containing None accepts JSON null
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "nullable_literal_test", "params": [null], "id": 1}',
+        {"jsonrpc": "2.0", "result": "None", "id": 1},
+        "Literal - null member"
+    )
+
+    # A nested Literal union arm accepts JSON null
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "nullable_literal_union_test", "params": [null], "id": 1}',
+        {"jsonrpc": "2.0", "result": "None", "id": 1},
+        "Literal union - null member"
+    )
+
+    # An Enum Literal whose JSON wire value is null also accepts JSON null
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "nullable_enum_literal_union_test", "params": [null], "id": 1}',
+        {"jsonrpc": "2.0", "result": "NULL", "id": 1},
+        "Enum Literal union - null wire value"
     )
 
     # Point TypedDict - valid dict

--- a/tests/jsonrpc_test.py
+++ b/tests/jsonrpc_test.py
@@ -47,6 +47,10 @@ def union_test(id: int | str | None | Point) -> str:
     return f"ID: {id or '<nil>'}"
 
 @jsonrpc.method
+def exact_union_test(value: float | bool | int) -> str:
+    return f"{type(value).__name__}:{value!r}"
+
+@jsonrpc.method
 def list_test(items: list[str]) -> int:
     return len(items)
 
@@ -72,6 +76,28 @@ class NullMode(Enum):
 @jsonrpc.method
 def nullable_enum_literal_union_test(mode: Literal[NullMode.NULL] | str) -> str:
     return mode.name if isinstance(mode, NullMode) else mode
+
+class Ratio(Enum):
+    ONE = 1.0
+
+@jsonrpc.method
+def numeric_enum_literal_test(ratio: Literal[Ratio.ONE]) -> str:
+    return ratio.name
+
+class BackendMode(Enum):
+    GUI = "gui"
+
+class NestedLiteralOptions(TypedDict):
+    backend: Literal[BackendMode.GUI]
+    fallbacks: list[Literal[BackendMode.GUI]]
+    aliases: dict[str, Literal[BackendMode.GUI]]
+
+@jsonrpc.method
+def nested_literal_test(options: NestedLiteralOptions) -> str:
+    assert options["backend"] is BackendMode.GUI
+    assert options["fallbacks"] == [BackendMode.GUI]
+    assert options["aliases"] == {"default": BackendMode.GUI}
+    return "ok"
 
 @jsonrpc.method
 def exception():
@@ -534,6 +560,18 @@ def run_all_tests():
         "Union type (int | str | None) - null value"
     )
 
+    # Exact union arms take precedence over int-to-float coercion
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "exact_union_test", "params": [true], "id": 1}',
+        {"jsonrpc": "2.0", "result": "bool:True", "id": 1},
+        "Union type - exact bool before float coercion"
+    )
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "exact_union_test", "params": [1], "id": 1}',
+        {"jsonrpc": "2.0", "result": "int:1", "id": 1},
+        "Union type - exact int before float coercion"
+    )
+
     # ========================================
     # OPTIONAL TYPE TESTS
     # ========================================
@@ -560,7 +598,7 @@ def run_all_tests():
     check_rpc(
         '{"jsonrpc": "2.0", "method": "list_test", "params": [["a", "b", "c"]], "id": 1}',
         {"jsonrpc": "2.0", "result": 3, "id": 1},
-        "Generic type list[str] - valid list (no inner validation)"
+        "Generic type list[str] - valid list"
     )
 
     # list[T] - wrong outer type
@@ -617,6 +655,48 @@ def run_all_tests():
         '{"jsonrpc": "2.0", "method": "nullable_enum_literal_union_test", "params": [null], "id": 1}',
         {"jsonrpc": "2.0", "result": "NULL", "id": 1},
         "Enum Literal union - null wire value"
+    )
+
+    # JSON integers and floats use the same numeric equality semantics
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "numeric_enum_literal_test", "params": [1], "id": 1}',
+        {"jsonrpc": "2.0", "result": "ONE", "id": 1},
+        "Enum Literal - equivalent JSON number"
+    )
+
+    # JSON booleans remain distinct from numbers
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "numeric_enum_literal_test", "params": [true], "id": 1}',
+        {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32602,
+                "message": "Invalid params: ratio expected one of [<Ratio.ONE: 1.0>], got True",
+            },
+            "id": 1,
+        },
+        "Enum Literal - boolean is not a number"
+    )
+
+    # Literal enum values are converted recursively inside containers
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "nested_literal_test", "params": [{"backend": "gui", "fallbacks": ["gui"], "aliases": {"default": "gui"}}], "id": 1}',
+        {"jsonrpc": "2.0", "result": "ok", "id": 1},
+        "Enum Literal - nested container conversion"
+    )
+
+    # Schema-invalid nested Literal values are rejected
+    check_rpc(
+        '{"jsonrpc": "2.0", "method": "nested_literal_test", "params": [{"backend": "other", "fallbacks": [], "aliases": {}}], "id": 1}',
+        {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32602,
+                "message": "Invalid params: options.backend expected one of [<BackendMode.GUI: 'gui'>], got 'other'",
+            },
+            "id": 1,
+        },
+        "Enum Literal - reject invalid nested value"
     )
 
     # Point TypedDict - valid dict

--- a/tests/mcp_test.py
+++ b/tests/mcp_test.py
@@ -194,17 +194,17 @@ async def exercise_edge_cases(prefix: str, session: ClientSession):
         assert "not found" in e.error.message, "expected method not found error"
         print(f"[{prefix}] Non-existent tool error: {e.error.message}")
 
-    # Test missing required parameter. 2025-11-25 reports tool input validation
+    # Test Python argument binding. 2025-11-25 reports invalid tool arguments
     # as a tool execution error; older versions report a protocol error.
     try:
         result = await session.call_tool("divide", arguments={"numerator": 42})
         assert result.isError, "missing denominator should return a tool error"
         content = result.content[0]
         assert isinstance(content, types.TextContent), "expected TextContent"
-        assert "missing required" in content.text, "expected missing parameter error"
+        assert "missing" in content.text, "expected missing parameter error"
         print(f"[{prefix}] Missing param tool error: {content.text}")
     except McpError as e:
-        assert "missing required" in e.error.message, "expected missing parameter error"
+        assert "missing" in e.error.message, "expected missing parameter error"
         print(f"[{prefix}] Missing param protocol error: {e.error.message}")
 
     # Test division by zero (natural exception)

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -6,8 +6,9 @@ import sys
 import socket
 import zlib
 from contextlib import contextmanager
+from enum import Enum
 from types import SimpleNamespace
-from typing import BinaryIO, cast
+from typing import BinaryIO, Literal, TypedDict, cast
 from zeromcp import McpAuthInfo, McpServer, McpHttpRequestHandler
 
 def find_free_port():
@@ -376,6 +377,60 @@ def test_tool_schema_includes_future_fields_for_all_versions():
             schema = server._dispatch_mcp(request)["result"]["tools"][0]
         assert schema["annotations"]["readOnlyHint"] is True
         assert schema["outputSchema"]["properties"]["result"]["type"] == "integer"
+    print("✓ PASS")
+
+
+def test_literal_fields_generate_json_schema_enums():
+    print("Testing Literal fields generate JSON Schema enums...")
+    server = McpServer("literal-schema-test")
+
+    class Backend(Enum):
+        GUI = "gui"
+        IDALIB = "idalib"
+
+    class Instance(TypedDict):
+        backend: Literal["gui", "idalib"]
+        status: Literal["available", "attached", "current", "unavailable"]
+
+    class Result(TypedDict):
+        instances: list[Instance]
+
+    @server.tool
+    def list_instances(backend: Literal[Backend.GUI, Backend.IDALIB] = Backend.GUI) -> Result:
+        assert isinstance(backend, Backend)
+        return {"instances": [{"backend": backend.value, "status": "available"}]}
+
+    response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "id": 1,
+    })
+    assert response is not None
+    json.dumps(response)
+    tool = response["result"]["tools"][0]
+    assert tool["inputSchema"]["properties"]["backend"] == {
+        "type": "string",
+        "enum": ["gui", "idalib"],
+    }
+    properties = tool["outputSchema"]["properties"]
+    instance_properties = properties["instances"]["items"]["properties"]
+    assert instance_properties["backend"] == {
+        "type": "string",
+        "enum": ["gui", "idalib"],
+    }
+    assert instance_properties["status"] == {
+        "type": "string",
+        "enum": ["available", "attached", "current", "unavailable"],
+    }
+
+    call_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"name": "list_instances", "arguments": {"backend": "idalib"}},
+        "id": 2,
+    })
+    assert call_response is not None
+    assert call_response["result"]["structuredContent"]["instances"][0]["backend"] == "idalib"
     print("✓ PASS")
 
 
@@ -1268,6 +1323,7 @@ def run_all_tests():
         test_stdio_preserves_negotiated_protocol_version()
         test_protocol_specific_tool_argument_errors()
         test_tool_schema_includes_future_fields_for_all_versions()
+        test_literal_fields_generate_json_schema_enums()
         test_str_tool_result_is_unstructured_text()
         test_sync_tool_can_bridge_to_async_in_sync_transport()
         test_request_context_meta_and_async_tool()

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -519,6 +519,45 @@ def test_enum_mapping_keys_are_serialized():
     print("✓ PASS")
 
 
+def test_enum_mapping_key_collisions_are_rejected():
+    print("Testing collisions between Enum and wire mapping keys are rejected...")
+    server = McpServer("enum-mapping-key-collision-test")
+
+    class Key(Enum):
+        NAME = "name"
+
+    class Choice(Enum):
+        DUPLICATE = {Key.NAME: 1, "name": 2}
+
+    @server.tool
+    def choose(value: Literal[Choice.DUPLICATE]) -> str:
+        return "unreachable"
+
+    list_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "id": 1,
+    })
+    assert list_response is not None
+    assert list_response["error"]["code"] == -32603
+    assert "normalizes to duplicate JSON key 'name'" in list_response["error"]["message"]
+
+    @server.tool
+    def duplicate_result() -> dict:
+        return {Key.NAME: 1, "name": 2}
+
+    call_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"name": "duplicate_result", "arguments": {}},
+        "id": 2,
+    })
+    assert call_response is not None
+    assert call_response["error"]["code"] == -32603
+    assert "normalizes to duplicate JSON key 'name'" in call_response["error"]["message"]
+    print("✓ PASS")
+
+
 def test_str_tool_result_is_unstructured_text():
     print("Testing string tool results are unstructured text...")
     server = McpServer("text-test")
@@ -1411,6 +1450,7 @@ def run_all_tests():
         test_literal_fields_generate_json_schema_enums()
         test_enum_literal_container_values()
         test_enum_mapping_keys_are_serialized()
+        test_enum_mapping_key_collisions_are_rejected()
         test_str_tool_result_is_unstructured_text()
         test_sync_tool_can_bridge_to_async_in_sync_transport()
         test_request_context_meta_and_async_tool()

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -436,6 +436,89 @@ def test_literal_fields_generate_json_schema_enums():
     print("✓ PASS")
 
 
+def test_enum_literal_container_values():
+    print("Testing container-valued Enum Literals...")
+    server = McpServer("literal-container-test")
+
+    class Token(Enum):
+        X = "x"
+
+    class Choice(Enum):
+        ITEMS = [Token.X, 1]
+        OPTIONS = {"token": Token.X, "counts": [1, 2.0]}
+
+    @server.tool
+    def choose(
+        items: Literal[Choice.ITEMS],
+        options: Literal[Choice.OPTIONS],
+    ) -> str:
+        assert items is Choice.ITEMS
+        assert options is Choice.OPTIONS
+        return "ok"
+
+    list_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "id": 1,
+    })
+    assert list_response is not None
+    json.dumps(list_response)
+    properties = list_response["result"]["tools"][0]["inputSchema"]["properties"]
+    assert properties["items"] == {
+        "type": "array",
+        "enum": [["x", 1]],
+    }
+    assert properties["options"] == {
+        "type": "object",
+        "enum": [{"token": "x", "counts": [1, 2.0]}],
+    }
+
+    call_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "choose",
+            "arguments": {
+                "items": ["x", 1.0],
+                "options": {"token": "x", "counts": [1.0, 2]},
+            },
+        },
+        "id": 2,
+    })
+    assert call_response is not None
+    assert call_response["result"]["content"][0]["text"] == "ok"
+    print("✓ PASS")
+
+
+def test_enum_mapping_keys_are_serialized():
+    print("Testing Enum mapping keys are serialized to their wire values...")
+    server = McpServer("enum-mapping-key-test")
+
+    class Key(Enum):
+        NAME = "name"
+
+    @server.tool
+    def echo(values: dict[Literal[Key.NAME], str]) -> dict[Literal[Key.NAME], str]:
+        assert values == {Key.NAME: "value"}
+        return values
+
+    response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "echo",
+            "arguments": {"values": {"name": "value"}},
+        },
+        "id": 1,
+    })
+    assert response is not None
+    json.dumps(response)
+    result = response["result"]
+    assert result["structuredContent"] == {"name": "value"}
+    assert json.loads(result["content"][0]["text"]) == {"name": "value"}
+    print("✓ PASS")
+
+
 def test_str_tool_result_is_unstructured_text():
     print("Testing string tool results are unstructured text...")
     server = McpServer("text-test")
@@ -1326,6 +1409,8 @@ def run_all_tests():
         test_protocol_specific_tool_argument_errors()
         test_tool_schema_includes_future_fields_for_all_versions()
         test_literal_fields_generate_json_schema_enums()
+        test_enum_literal_container_values()
+        test_enum_mapping_keys_are_serialized()
         test_str_tool_result_is_unstructured_text()
         test_sync_tool_can_bridge_to_async_in_sync_transport()
         test_request_context_meta_and_async_tool()

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -329,7 +329,7 @@ def test_stdio_preserves_negotiated_protocol_version():
     assert responses[0]["result"]["protocolVersion"] == "2025-11-25"
     tool_result = responses[1]["result"]
     assert tool_result["isError"]
-    assert "missing required" in tool_result["content"][0]["text"]
+    assert "missing" in tool_result["content"][0]["text"]
     print("✓ PASS")
 
 
@@ -358,7 +358,7 @@ def test_protocol_specific_tool_argument_errors():
     assert new_response is not None
     result = new_response["result"]
     assert result["isError"] is True, "2025-11-25 treats invalid tool args as tool execution errors"
-    assert "missing required" in result["content"][0]["text"]
+    assert "missing" in result["content"][0]["text"]
     print("✓ PASS")
 
 
@@ -384,7 +384,7 @@ def test_literal_fields_generate_json_schema_enums():
     print("Testing Literal fields generate JSON Schema enums...")
     server = McpServer("literal-schema-test")
 
-    class Backend(Enum):
+    class Backend(str, Enum):
         GUI = "gui"
         IDALIB = "idalib"
 
@@ -397,7 +397,6 @@ def test_literal_fields_generate_json_schema_enums():
 
     @server.tool
     def list_instances(backend: Literal[Backend.GUI, Backend.IDALIB] = Backend.GUI) -> Result:
-        assert isinstance(backend, Backend)
         return {"instances": [{"backend": backend, "status": "available"}]}
 
     response = server._dispatch_mcp({
@@ -411,6 +410,7 @@ def test_literal_fields_generate_json_schema_enums():
     assert tool["inputSchema"]["properties"]["backend"] == {
         "type": "string",
         "enum": ["gui", "idalib"],
+        "default": "gui",
     }
     properties = tool["outputSchema"]["properties"]
     instance_properties = properties["instances"]["items"]["properties"]
@@ -433,128 +433,36 @@ def test_literal_fields_generate_json_schema_enums():
     json.dumps(call_response)
     assert call_response["result"]["structuredContent"]["instances"][0]["backend"] == "idalib"
     assert json.loads(call_response["result"]["content"][0]["text"])["instances"][0]["backend"] == "idalib"
+
+    # Clients enforce the advertised enum. The server passes decoded JSON through.
+    unchecked_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"name": "list_instances", "arguments": {"backend": "unchecked"}},
+        "id": 3,
+    })
+    assert unchecked_response is not None
+    assert unchecked_response["result"]["structuredContent"]["instances"][0]["backend"] == "unchecked"
     print("✓ PASS")
 
 
-def test_enum_literal_container_values():
-    print("Testing container-valued Enum Literals...")
-    server = McpServer("literal-container-test")
+def test_literal_enums_must_derive_from_str():
+    print("Testing only str-derived Enum Literals are supported...")
+    server = McpServer("literal-enum-type-test")
 
-    class Token(Enum):
-        X = "x"
+    class Plain(Enum):
+        VALUE = "value"
 
-    class Choice(Enum):
-        ITEMS = [Token.X, 1]
-        OPTIONS = {"token": Token.X, "counts": [1, 2.0]}
+    class Numeric(Enum):
+        VALUE = 1
 
-    @server.tool
-    def choose(
-        items: Literal[Choice.ITEMS],
-        options: Literal[Choice.OPTIONS],
-    ) -> str:
-        assert items is Choice.ITEMS
-        assert options is Choice.OPTIONS
-        return "ok"
-
-    list_response = server._dispatch_mcp({
-        "jsonrpc": "2.0",
-        "method": "tools/list",
-        "id": 1,
-    })
-    assert list_response is not None
-    json.dumps(list_response)
-    properties = list_response["result"]["tools"][0]["inputSchema"]["properties"]
-    assert properties["items"] == {
-        "type": "array",
-        "enum": [["x", 1]],
-    }
-    assert properties["options"] == {
-        "type": "object",
-        "enum": [{"token": "x", "counts": [1, 2.0]}],
-    }
-
-    call_response = server._dispatch_mcp({
-        "jsonrpc": "2.0",
-        "method": "tools/call",
-        "params": {
-            "name": "choose",
-            "arguments": {
-                "items": ["x", 1.0],
-                "options": {"token": "x", "counts": [1.0, 2]},
-            },
-        },
-        "id": 2,
-    })
-    assert call_response is not None
-    assert call_response["result"]["content"][0]["text"] == "ok"
-    print("✓ PASS")
-
-
-def test_enum_mapping_keys_are_serialized():
-    print("Testing Enum mapping keys are serialized to their wire values...")
-    server = McpServer("enum-mapping-key-test")
-
-    class Key(Enum):
-        NAME = "name"
-
-    @server.tool
-    def echo(values: dict[Literal[Key.NAME], str]) -> dict[Literal[Key.NAME], str]:
-        assert values == {Key.NAME: "value"}
-        return values
-
-    response = server._dispatch_mcp({
-        "jsonrpc": "2.0",
-        "method": "tools/call",
-        "params": {
-            "name": "echo",
-            "arguments": {"values": {"name": "value"}},
-        },
-        "id": 1,
-    })
-    assert response is not None
-    json.dumps(response)
-    result = response["result"]
-    assert result["structuredContent"] == {"name": "value"}
-    assert json.loads(result["content"][0]["text"]) == {"name": "value"}
-    print("✓ PASS")
-
-
-def test_enum_mapping_key_collisions_are_rejected():
-    print("Testing collisions between Enum and wire mapping keys are rejected...")
-    server = McpServer("enum-mapping-key-collision-test")
-
-    class Key(Enum):
-        NAME = "name"
-
-    class Choice(Enum):
-        DUPLICATE = {Key.NAME: 1, "name": 2}
-
-    @server.tool
-    def choose(value: Literal[Choice.DUPLICATE]) -> str:
-        return "unreachable"
-
-    list_response = server._dispatch_mcp({
-        "jsonrpc": "2.0",
-        "method": "tools/list",
-        "id": 1,
-    })
-    assert list_response is not None
-    assert list_response["error"]["code"] == -32603
-    assert "normalizes to duplicate JSON key 'name'" in list_response["error"]["message"]
-
-    @server.tool
-    def duplicate_result() -> dict:
-        return {Key.NAME: 1, "name": 2}
-
-    call_response = server._dispatch_mcp({
-        "jsonrpc": "2.0",
-        "method": "tools/call",
-        "params": {"name": "duplicate_result", "arguments": {}},
-        "id": 2,
-    })
-    assert call_response is not None
-    assert call_response["error"]["code"] == -32603
-    assert "normalizes to duplicate JSON key 'name'" in call_response["error"]["message"]
+    for annotation in (Literal[Plain.VALUE], Literal[Numeric.VALUE]):
+        try:
+            server._type_to_json_schema(annotation)
+        except TypeError as exc:
+            assert "must derive from str" in str(exc)
+        else:
+            raise AssertionError(f"Expected {annotation!r} to be rejected")
     print("✓ PASS")
 
 
@@ -1448,9 +1356,7 @@ def run_all_tests():
         test_protocol_specific_tool_argument_errors()
         test_tool_schema_includes_future_fields_for_all_versions()
         test_literal_fields_generate_json_schema_enums()
-        test_enum_literal_container_values()
-        test_enum_mapping_keys_are_serialized()
-        test_enum_mapping_key_collisions_are_rejected()
+        test_literal_enums_must_derive_from_str()
         test_str_tool_result_is_unstructured_text()
         test_sync_tool_can_bridge_to_async_in_sync_transport()
         test_request_context_meta_and_async_tool()

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -446,23 +446,65 @@ def test_literal_fields_generate_json_schema_enums():
     print("✓ PASS")
 
 
-def test_literal_enums_must_derive_from_str():
-    print("Testing only str-derived Enum Literals are supported...")
+def test_literal_enum_schema_uses_scalar_values():
+    print("Testing Literal Enum schemas use string and numeric values...")
     server = McpServer("literal-enum-type-test")
 
-    class Plain(Enum):
+    class Label(Enum):
         VALUE = "value"
 
-    class Numeric(Enum):
-        VALUE = 1
+    class Count(Enum):
+        ONE = 1
 
-    for annotation in (Literal[Plain.VALUE], Literal[Numeric.VALUE]):
-        try:
-            server._type_to_json_schema(annotation)
-        except TypeError as exc:
-            assert "must derive from str" in str(exc)
-        else:
-            raise AssertionError(f"Expected {annotation!r} to be rejected")
+    class Ratio(Enum):
+        HALF = 0.5
+
+    class Unsupported(Enum):
+        VALUES = [1, 2]
+
+    assert server._type_to_json_schema(Literal[Label.VALUE]) == {
+        "type": "string",
+        "enum": ["value"],
+    }
+    assert server._type_to_json_schema(Literal[Count.ONE]) == {
+        "type": "integer",
+        "enum": [1],
+    }
+    assert server._type_to_json_schema(Literal[Ratio.HALF]) == {
+        "type": "number",
+        "enum": [0.5],
+    }
+
+    @server.tool
+    def choose(count: Literal[Count.ONE] = Count.ONE, ratio: Literal[Ratio.HALF] = Ratio.HALF) -> dict:
+        return {"count": count, "ratio": ratio}
+
+    list_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "id": 1,
+    })
+    assert list_response is not None
+    json.dumps(list_response)
+    properties = list_response["result"]["tools"][0]["inputSchema"]["properties"]
+    assert properties["count"] == {"type": "integer", "enum": [1], "default": 1}
+    assert properties["ratio"] == {"type": "number", "enum": [0.5], "default": 0.5}
+
+    call_response = server._dispatch_mcp({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"name": "choose", "arguments": {"count": 1, "ratio": 0.5}},
+        "id": 2,
+    })
+    assert call_response is not None
+    assert call_response["result"]["structuredContent"] == {"count": 1, "ratio": 0.5}
+
+    try:
+        server._type_to_json_schema(Literal[Unsupported.VALUES])
+    except TypeError as exc:
+        assert "must have a str, int, or float value" in str(exc)
+    else:
+        raise AssertionError("Expected container-valued Enum Literal to be rejected")
     print("✓ PASS")
 
 
@@ -1356,7 +1398,7 @@ def run_all_tests():
         test_protocol_specific_tool_argument_errors()
         test_tool_schema_includes_future_fields_for_all_versions()
         test_literal_fields_generate_json_schema_enums()
-        test_literal_enums_must_derive_from_str()
+        test_literal_enum_schema_uses_scalar_values()
         test_str_tool_result_is_unstructured_text()
         test_sync_tool_can_bridge_to_async_in_sync_transport()
         test_request_context_meta_and_async_tool()

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -389,7 +389,7 @@ def test_literal_fields_generate_json_schema_enums():
         IDALIB = "idalib"
 
     class Instance(TypedDict):
-        backend: Literal["gui", "idalib"]
+        backend: Literal[Backend.GUI, Backend.IDALIB]
         status: Literal["available", "attached", "current", "unavailable"]
 
     class Result(TypedDict):
@@ -398,7 +398,7 @@ def test_literal_fields_generate_json_schema_enums():
     @server.tool
     def list_instances(backend: Literal[Backend.GUI, Backend.IDALIB] = Backend.GUI) -> Result:
         assert isinstance(backend, Backend)
-        return {"instances": [{"backend": backend.value, "status": "available"}]}
+        return {"instances": [{"backend": backend, "status": "available"}]}
 
     response = server._dispatch_mcp({
         "jsonrpc": "2.0",
@@ -430,7 +430,9 @@ def test_literal_fields_generate_json_schema_enums():
         "id": 2,
     })
     assert call_response is not None
+    json.dumps(call_response)
     assert call_response["result"]["structuredContent"]["instances"][0]["backend"] == "idalib"
+    assert json.loads(call_response["result"]["content"][0]["text"])["instances"][0]["backend"] == "idalib"
     print("✓ PASS")
 
 


### PR DESCRIPTION
## Summary

- support Enum Literals backed by `str`, `int`, or `float` values in generated schemas
- reject container-valued Enums and remove all Enum-key rewriting
- stop revalidating decoded parameters against Python annotations; pass them directly to handlers and let Python report argument-binding errors
- normalize scalar Enum defaults while generating tool schemas
- cache stable tool metadata used on the hot path
- add `benchmarks/dispatch.py` for repeatable in-process overhead measurements

This avoids mapping normalization/collision edge cases entirely. Type annotations remain the source for the schema reported to MCP clients, while runtime dispatch stays small.

## Performance

Steady-state median on Python 3.11/Windows (9 runs):

| Path | Before | After | Change |
|---|---:|---:|---:|
| JSON-RPC, decoded dict | 4.89 µs | 1.69 µs | -65% |
| JSON-RPC, JSON string | 7.28 µs | 3.74 µs | -49% |
| MCP `tools/call`, decoded dict | 43.68 µs | 18.07 µs | -59% |
| MCP `tools/call`, JSON string | 49.27 µs | 22.34 µs | -55% |

Run with `uv run benchmarks/dispatch.py`.

## Validation

- `uv run pytest -q` (53 passed)
- `uv run tests/jsonrpc_test.py`
- `uv run tests/mcp_test.py`
- `uv run tests/server_test.py`
- `uv run tests/future_annotations_test.py`
- `uvx ruff@0.14.0 check`
- `uvx ty@0.0.63 check`
